### PR TITLE
Adds the ability to signal an error condition when queueing

### DIFF
--- a/device/src/devices/video_decoder.rs
+++ b/device/src/devices/video_decoder.rs
@@ -109,7 +109,11 @@ pub enum VideoDecoderBackendEvent {
     /// [`VideoDecoderBackendSession::current_format`].
     StreamFormatChanged,
     /// Sent whenever an `OUTPUT` buffer is done processing and can be reused.
-    InputBufferDone(u32),
+    InputBufferDone {
+        buffer_id: u32,
+        /// If error != 0, indicate the error flag on the corresponding v4l2_buffer
+        error: i32,
+    },
     /// Sent whenever a decoded frame is ready on the `CAPTURE` queue.
     FrameCompleted {
         buffer_id: u32,
@@ -678,13 +682,17 @@ where
     fn process_events(&mut self, session: &mut Self::Session) -> Result<(), i32> {
         let has_event = if let Some(event) = session.backend_session.next_event() {
             match event {
-                VideoDecoderBackendEvent::InputBufferDone(id) => {
+                VideoDecoderBackendEvent::InputBufferDone { buffer_id: id, error } => {
                     let Some(buffer) = session.input_buffers.get_mut(id as usize) else {
                         log::error!("no matching OUTPUT buffer with id {} to process event", id);
                         return Ok(());
                     };
 
                     buffer.v4l2_buffer.clear_flags(BufferFlags::QUEUED);
+
+                    if error != 0 {
+                        buffer.v4l2_buffer.set_flags(BufferFlags::ERROR);
+                    }
 
                     self.event_queue
                         .send_event(V4l2Event::DequeueBuffer(DequeueBufferEvent::new(

--- a/extras/ffmpeg-decoder/src/event_queue.rs
+++ b/extras/ffmpeg-decoder/src/event_queue.rs
@@ -94,7 +94,10 @@ mod tests {
         let mut event_queue = EventQueue::new().unwrap();
 
         event_queue
-            .queue_event(VideoDecoderBackendEvent::InputBufferDone(1))
+            .queue_event(VideoDecoderBackendEvent::InputBufferDone {
+                buffer_id: 1,
+                error: 0
+            })
             .unwrap();
         assert_eq!(event_queue.len(), 1);
         event_queue
@@ -112,7 +115,10 @@ mod tests {
 
         assert!(matches!(
             event_queue.dequeue_event(),
-            Some(VideoDecoderBackendEvent::InputBufferDone(1))
+            Some(VideoDecoderBackendEvent::InputBufferDone {
+                buffer_id: 1,
+                error: 0
+            })
         ));
         assert_eq!(event_queue.len(), 1);
         assert_eq!(
@@ -147,31 +153,49 @@ mod tests {
 
         // `event_pipe` should signal as long as the queue is not empty.
         event_queue
-            .queue_event(VideoDecoderBackendEvent::InputBufferDone(1))
+            .queue_event(VideoDecoderBackendEvent::InputBufferDone {
+                buffer_id: 1,
+                error: 0
+            })
             .unwrap();
         assert_eq!(epoll.wait(&mut events, EpollTimeout::ZERO).unwrap(), 1);
         event_queue
-            .queue_event(VideoDecoderBackendEvent::InputBufferDone(2))
+            .queue_event(VideoDecoderBackendEvent::InputBufferDone {
+                buffer_id: 2,
+                error: 0
+            })
             .unwrap();
         assert_eq!(epoll.wait(&mut events, EpollTimeout::ZERO).unwrap(), 1);
         event_queue
-            .queue_event(VideoDecoderBackendEvent::InputBufferDone(3))
+            .queue_event(VideoDecoderBackendEvent::InputBufferDone {
+                buffer_id: 3,
+                error: 0
+            })
             .unwrap();
         assert_eq!(epoll.wait(&mut events, EpollTimeout::ZERO).unwrap(), 1);
 
         assert_eq!(
             event_queue.dequeue_event(),
-            Some(VideoDecoderBackendEvent::InputBufferDone(1))
+            Some(VideoDecoderBackendEvent::InputBufferDone {
+                buffer_id: 1,
+                error: 0
+            })
         );
         assert_eq!(epoll.wait(&mut events, EpollTimeout::ZERO).unwrap(), 1);
         assert_eq!(
             event_queue.dequeue_event(),
-            Some(VideoDecoderBackendEvent::InputBufferDone(2))
+            Some(VideoDecoderBackendEvent::InputBufferDone {
+                buffer_id: 2,
+                error: 0
+            })
         );
         assert_eq!(epoll.wait(&mut events, EpollTimeout::ZERO).unwrap(), 1);
         assert_eq!(
             event_queue.dequeue_event(),
-            Some(VideoDecoderBackendEvent::InputBufferDone(3))
+            Some(VideoDecoderBackendEvent::InputBufferDone {
+                buffer_id: 3,
+                error: 0
+            })
         );
 
         // The queue is empty again, so `event_pipe` should not signal.

--- a/extras/ffmpeg-decoder/src/lib.rs
+++ b/extras/ffmpeg-decoder/src/lib.rs
@@ -404,7 +404,10 @@ impl FfmpegDecoderSession {
                     false => context.jobs.push_front(next_job),
                     true => self
                         .events
-                        .queue_event(VideoDecoderBackendEvent::InputBufferDone(*input_index))
+                        .queue_event(VideoDecoderBackendEvent::InputBufferDone {
+                            buffer_id: *input_index,
+                            error: 0
+                        })
                         .map_err(TrySendInputError::EventQueue)?,
                 }
 


### PR DESCRIPTION
VideoDecoderBackendEvent::InputBufferDone, any non-zero error signaled will have the corresponding v4l2_buffer returned to the client with an ERROR flag.