### PR TITLE
Various fixes for ffmpeg and v4l2-proxy backends

### DIFF
--- a/device/src/devices/v4l2_device_proxy.rs
+++ b/device/src/devices/v4l2_device_proxy.rs
@@ -1104,8 +1104,10 @@ where
         )
         .map_err(|e| (e.into_errno()))?;
 
-        let bufs_range = create_bufs.index..(create_bufs.index + create_bufs.count);
-        self.update_mmap_offsets(session, queue, bufs_range);
+        if count > 0 {
+            let bufs_range = create_bufs.index..(create_bufs.index + create_bufs.count);
+            self.update_mmap_offsets(session, queue, bufs_range);
+        }
 
         Ok(create_bufs)
     }

--- a/extras/ffmpeg-decoder/Cargo.toml
+++ b/extras/ffmpeg-decoder/Cargo.toml
@@ -13,5 +13,5 @@ thiserror = "1.0"
 virtio-media = { path = "../../device" }
 
 [build-dependencies]
-bindgen = "0.63"
+bindgen = "0.70.1"
 pkg-config = "0.3"

--- a/extras/ffmpeg-decoder/src/ffmpeg/avcodec.rs
+++ b/extras/ffmpeg-decoder/src/ffmpeg/avcodec.rs
@@ -63,6 +63,8 @@ pub struct AvCodec(&'static ffi::AVCodec);
 
 /// SAFETY: `AVCodec` is static and thus safe to share.
 unsafe impl Send for AvCodec {}
+/// SAFETY:  Safe to `Sync` because none of `AVCodec` methods can ever change its state.
+unsafe impl Sync for AvCodec {}
 
 #[derive(Debug, ThisError)]
 pub enum AvCodecOpenError {
@@ -468,6 +470,11 @@ impl Iterator for AvPixelFormatIterator {
 /// A codec context from which decoding can be performed.
 pub struct AvCodecContext(*mut ffi::AVCodecContext);
 
+/// SAFETY: safe because mutable pointers are exclusive and valid (implicit lifetime annotation).
+unsafe impl Send for AvCodecContext {}
+/// SAFETY: safe because it does not allow mutable aliasing.
+unsafe impl Sync for AvCodecContext {}
+
 impl Drop for AvCodecContext {
     fn drop(&mut self) {
         // SAFETY:
@@ -747,6 +754,11 @@ pub struct AvPacket<'a> {
     _buffer_data: PhantomData<&'a ()>,
 }
 
+/// SAFETY: safe because data in 'AvPacket' is valid, and thus safe to send its reference.
+unsafe impl<'a> Send for AvPacket<'a> {}
+/// SAFETY: safe because it does not allow mutable aliasing.
+unsafe impl<'a> Sync for AvPacket<'a> {}
+
 impl<'a> Drop for AvPacket<'a> {
     fn drop(&mut self) {
         // SAFETY:
@@ -834,6 +846,11 @@ impl<'a> AvPacket<'a> {
 /// An owned AVFrame, i.e. one decoded frame from libavcodec that can be converted into a
 /// destination buffer.
 pub struct AvFrame(*mut ffi::AVFrame);
+
+/// SAFETY: safe because mutable pointers are exclusive and valid (implicit lifetime annotation).
+unsafe impl Send for AvFrame {}
+/// SAFETY: safe because it does not allow mutable aliasing.
+unsafe impl Sync for AvFrame {}
 
 /// A builder for AVFrame that allows specifying buffers and image metadata.
 pub struct AvFrameBuilder(AvFrame);

--- a/extras/ffmpeg-decoder/src/ffmpeg/swscale.rs
+++ b/extras/ffmpeg-decoder/src/ffmpeg/swscale.rs
@@ -21,6 +21,11 @@ pub struct SwConverter {
     dst_pix_format: ffi::AVPixelFormat,
 }
 
+/// SAFETY: safe because mutable pointers are exclusive and valid (implicit lifetime annotation).
+unsafe impl Send for SwConverter {}
+/// SAFETY: safe because it does not allow mutable aliasing.
+unsafe impl Sync for SwConverter {}  
+
 #[derive(Debug, ThisError)]
 pub enum ConversionError {
     #[error("AvFrame's format {frame} does not match converter {converter} configuration")]


### PR DESCRIPTION
A mix of different non-related fixes.

Fixes include:
- New clang include for ffmpeg buildgen
- Bump bindgen version (see https://github.com/Gnurou/v4l2r/pull/40)
- Make ffmpeg send+sync (tried to do my best to write safety comments)
  - This is required because my implementation on rust-vmm requires it
- Small check for create_bufs in v4l2_proxy backend

> If count == 0, then ioctl VIDIOC_CREATE_BUFS will set index to the current number of created buffers, and it will check the validity of memory and format.type.

So we do not want to clear buffers when we receive this.

If this PR feels a bit messy, as it includes different unrelated fixes, I will split them.