### PR TITLE
Ensure license file is published with Rust crate

### DIFF
--- a/device/Cargo.toml
+++ b/device/Cargo.toml
@@ -2,6 +2,7 @@
 name = "virtio-media"
 version = "0.0.7"
 license = "BSD-3-Clause"
+license-file = "../LICENSE"
 description = "Device support for virtio-media"
 repository = "https://github.com/chromeos/virtio-media"
 authors = ["The ChromiumOS Authors"]


### PR DESCRIPTION
As the license file is present at the root of the repository, it isn't part of the `virtio-media` crate on crates.io, as it lies in a subfolder. Ensure this file is published by telling cargo where to find it.