### PR TITLE
device/ffmpeg-decode: media crate in Cargo.toml

### DIFF
--- a/extras/ffmpeg-decoder/Cargo.toml
+++ b/extras/ffmpeg-decoder/Cargo.toml
@@ -10,7 +10,7 @@ libc = "0.2.155"
 log = "0.4.20"
 nix = { version = "0.28", features = ["fs", "mman"] }
 thiserror = "1.0"
-virtio-media = { path = "../../device" }
+virtio-media = { version = "0.0.7" }
 
 [build-dependencies]
 bindgen = "0.70.1"


### PR DESCRIPTION
In order to add the latest published virtio-media
crate and "virtio-media-ffmpeg-decoder" as
dependencies simoultaneously, the latter cannot
rely on the upstream folder in its Cargo.toml.
Otherwise, the `VirtioDecoderBackend` will
differ and the package using them will fail
to build.

Instead, just use the published crate in
crates.io to be consistent.