### PR TITLE
Update v4l2r dependency to v0.0.7

### DIFF
--- a/device/Cargo.lock
+++ b/device/Cargo.lock
@@ -164,6 +164,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "prettyplease"
 version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -271,9 +277,9 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "v4l2r"
-version = "0.0.6"
+version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f8945ec08a0f9c9b3596c3437bfc8ed1e5c4feefcc230ecf5641aa9b44392b"
+checksum = "2b609e6cc820e3f95dac66f8ef4efbdf1f39b8d119ec16e6476f797ec95ebaa7"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -281,6 +287,7 @@ dependencies = [
  "enumn",
  "log",
  "nix",
+ "paste",
  "thiserror",
 ]
 

--- a/device/Cargo.toml
+++ b/device/Cargo.toml
@@ -16,7 +16,7 @@ log = "0.4.20"
 nix = { version = "0.28", features = ["fs"] }
 thiserror = "1.0.38"
 # Use 64-bit bindings as this is the format used by virtio-media
-v4l2r = { version = "0.0.6", features = ["arch64"] }
+v4l2r = { version = "0.0.7", features = ["arch64"] }
 zerocopy = { version = "0.8.11", features = ["derive"] }
 
 [features]

--- a/device/src/devices/simple_device.rs
+++ b/device/src/devices/simple_device.rs
@@ -120,7 +120,7 @@ pub struct SimpleCaptureDeviceSession {
 }
 
 impl VirtioMediaDeviceSession for SimpleCaptureDeviceSession {
-    fn poll_fd(&self) -> Option<BorrowedFd> {
+    fn poll_fd(&self) -> Option<BorrowedFd<'_>> {
         None
     }
 }

--- a/device/src/devices/simple_device.rs
+++ b/device/src/devices/simple_device.rs
@@ -24,6 +24,7 @@ use v4l2r::bindings::v4l2_requestbuffers;
 use v4l2r::ioctl::BufferCapabilities;
 use v4l2r::ioctl::BufferField;
 use v4l2r::ioctl::BufferFlags;
+use v4l2r::ioctl::MemoryConsistency;
 use v4l2r::ioctl::V4l2Buffer;
 use v4l2r::ioctl::V4l2PlanesWithBackingMut;
 use v4l2r::memory::MemoryType;
@@ -378,6 +379,7 @@ where
         queue: QueueType,
         memory: MemoryType,
         count: u32,
+        flags: MemoryConsistency,
     ) -> IoctlResult<v4l2_requestbuffers> {
         if queue != QueueType::VideoCapture {
             return Err(libc::EINVAL);
@@ -461,6 +463,7 @@ where
             capabilities: (BufferCapabilities::SUPPORTS_MMAP
                 | BufferCapabilities::SUPPORTS_ORPHANED_BUFS)
                 .bits(),
+            flags: flags.bits(),
             ..Default::default()
         })
     }

--- a/device/src/devices/v4l2_device_proxy.rs
+++ b/device/src/devices/v4l2_device_proxy.rs
@@ -264,7 +264,7 @@ pub struct V4l2Session<M: VirtioMediaGuestMemoryMapper> {
 }
 
 impl<M: VirtioMediaGuestMemoryMapper> VirtioMediaDeviceSession for V4l2Session<M> {
-    fn poll_fd(&self) -> Option<BorrowedFd> {
+    fn poll_fd(&self) -> Option<BorrowedFd<'_>> {
         Some(self.poller.as_fd())
     }
 }
@@ -1104,7 +1104,7 @@ where
             memory,
             format,
         )
-        .map_err(|e| (e.into_errno()))?;
+        .map_err(|e| e.into_errno())?;
 
         if count > 0 {
             let bufs_range = create_bufs.index..(create_bufs.index + create_bufs.count);

--- a/device/src/devices/v4l2_device_proxy.rs
+++ b/device/src/devices/v4l2_device_proxy.rs
@@ -63,6 +63,7 @@ use v4l2r::ioctl::EventType as V4l2EventType;
 use v4l2r::ioctl::ExpbufFlags;
 use v4l2r::ioctl::ExtControlError;
 use v4l2r::ioctl::IntoErrno;
+use v4l2r::ioctl::MemoryConsistency;
 use v4l2r::ioctl::QueryCapError;
 use v4l2r::ioctl::QueryCtrlFlags;
 use v4l2r::ioctl::SelectionFlags;
@@ -611,9 +612,10 @@ where
         queue: QueueType,
         memory: MemoryType,
         count: u32,
+        flags: MemoryConsistency,
     ) -> IoctlResult<v4l2_requestbuffers> {
         let mut reqbufs: v4l2_requestbuffers =
-            v4l2r::ioctl::reqbufs(&session.device, queue, memory, count)
+            v4l2r::ioctl::reqbufs(&session.device, queue, memory, count, flags)
                 .map_err(IntoErrno::into_errno)?;
 
         // We do not support requests at the moment, so do not advertize them.

--- a/device/src/devices/video_decoder.rs
+++ b/device/src/devices/video_decoder.rs
@@ -51,7 +51,7 @@ pub trait VideoDecoderBufferBacking {
     where
         Self: Sized;
 
-    fn fd_for_plane(&self, plane_idx: usize) -> Option<BorrowedFd>;
+    fn fd_for_plane(&self, plane_idx: usize) -> Option<BorrowedFd<'_>>;
 }
 
 pub struct VideoDecoderBuffer<S: VideoDecoderBufferBacking> {
@@ -183,7 +183,7 @@ pub trait VideoDecoderBackendSession {
 
     /// Returns a file descriptor that signals `POLLIN` whenever an event is pending and can be
     /// read using [`next_event`], or `None` if the backend does not support this.
-    fn poll_fd(&self) -> Option<BorrowedFd> {
+    fn poll_fd(&self) -> Option<BorrowedFd<'_>> {
         None
     }
 
@@ -400,7 +400,7 @@ pub struct VideoDecoderSession<S: VideoDecoderBackendSession> {
 }
 
 impl<S: VideoDecoderBackendSession> VirtioMediaDeviceSession for VideoDecoderSession<S> {
-    fn poll_fd(&self) -> Option<BorrowedFd> {
+    fn poll_fd(&self) -> Option<BorrowedFd<'_>> {
         self.backend_session.poll_fd()
     }
 }

--- a/device/src/lib.rs
+++ b/device/src/lib.rs
@@ -148,7 +148,7 @@ pub trait VirtioMediaDeviceSession {
     ///
     /// If this method returns `None`, then the session does not need to be polled by the client,
     /// and `process_events` does not need to be called either.
-    fn poll_fd(&self) -> Option<BorrowedFd>;
+    fn poll_fd(&self) -> Option<BorrowedFd<'_>>;
 }
 
 /// Trait for implementing virtio-media devices.

--- a/device/src/mmap.rs
+++ b/device/src/mmap.rs
@@ -133,7 +133,7 @@ impl<M: VirtioMediaHostMemoryMapper> MmapMappingManager<M> {
                 .last()
                 // Align the start offset to the next page, or `register_buffer_by_offset` will
                 // fail.
-                .map(|b| ((b.offset + 1).next_multiple_of(PAGE_SIZE)))
+                .map(|b| (b.offset + 1).next_multiple_of(PAGE_SIZE))
                 .unwrap_or(0)
         });
 


### PR DESCRIPTION
v4l2r has changed the signature of the ioctl::reqbufs. It now includes a flags member for memory consistency that matches with the v4l2 linux headers.