### PR TITLE
Update to file param in v4l2_fh_{add|del}

### DIFF
--- a/driver/session.h
+++ b/driver/session.h
@@ -10,6 +10,7 @@
 #define __VIRTIO_MEDIA_SESSION_H
 
 #include <linux/scatterlist.h>
+#include <linux/version.h>
 #include <media/v4l2-fh.h>
 
 #include "protocol.h"
@@ -57,6 +58,7 @@ struct virtio_media_queue_state {
 /**
  * struct virtio_media_session - A session on a virtio_media device.
  * @fh: file handler for the session.
+ * @file: file pointer associated with the session's file handler.
  * @id: session ID used to communicate with the device.
  * @nonblocking_dequeue: whether dequeue should block or not (nonblocking if
  * file opened with O_NONBLOCK).
@@ -75,6 +77,7 @@ struct virtio_media_queue_state {
  */
 struct virtio_media_session {
 	struct v4l2_fh fh;
+        struct file *file;
 	u32 id;
 	bool nonblocking_dequeue;
 	bool uses_mplane;
@@ -105,5 +108,24 @@ static inline struct virtio_media_session *fh_to_session(struct v4l2_fh *fh)
 {
 	return container_of(fh, struct virtio_media_session, fh);
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 18, 0)
+static inline void
+virtio_media_session_fh_add(struct virtio_media_session *session,
+			    struct file *file)
+{
+	v4l2_fh_add(&session->fh, file);
+	session->file = file;
+}
+
+static inline void
+virtio_media_session_fh_del(struct virtio_media_session *session)
+{
+	v4l2_fh_del(&session->fh, session->file);
+}
+#else
+#define virtio_media_session_fh_add(session, file) v4l2_fh_add(&(session)->fh)
+#define virtio_media_session_fh_del(session)       v4l2_fh_del(&(session)->fh)
+#endif
 
 #endif // __VIRTIO_MEDIA_SESSION_H

--- a/driver/virtio_media_driver.c
+++ b/driver/virtio_media_driver.c
@@ -74,7 +74,7 @@ module_param_named(allow_userptr, virtio_media_allow_userptr, bool, 0660);
  */
 static struct virtio_media_session *
 virtio_media_session_alloc(struct virtio_media *vv, u32 id,
-			   bool nonblocking_dequeue)
+			   struct file *file)
 {
 	struct virtio_media_session *session;
 	int i;
@@ -94,11 +94,11 @@ virtio_media_session_alloc(struct virtio_media *vv, u32 id,
 		goto err_payload_sgs;
 
 	session->id = id;
-	session->nonblocking_dequeue = nonblocking_dequeue;
+	session->nonblocking_dequeue = file->f_flags & O_NONBLOCK;
 
 	INIT_LIST_HEAD(&session->list);
 	v4l2_fh_init(&session->fh, &vv->video_dev);
-	v4l2_fh_add(&session->fh);
+	virtio_media_session_fh_add(session, file);
 
 	for (i = 0; i <= VIRTIO_MEDIA_LAST_QUEUE; i++)
 		INIT_LIST_HEAD(&session->queues[i].pending_dqbufs);
@@ -137,7 +137,7 @@ static void virtio_media_session_free(struct virtio_media *vv,
 	list_del(&session->list);
 	mutex_unlock(&vv->sessions_lock);
 
-	v4l2_fh_del(&session->fh);
+	virtio_media_session_fh_del(session);
 	v4l2_fh_exit(&session->fh);
 
 	sg_free_table(&session->command_sgs);
@@ -607,8 +607,7 @@ static int virtio_media_device_open(struct file *file)
 	if (ret < 0)
 		return ret;
 
-	session = virtio_media_session_alloc(vv, session_id,
-					     (file->f_flags & O_NONBLOCK));
+	session = virtio_media_session_alloc(vv, session_id, file);
 	if (IS_ERR(session))
 		return PTR_ERR(session);
 


### PR DESCRIPTION
In v6.18 upstream reworked the v4l2_fh_add() and v4l2_fh_del() calls to take the file pointer as argument and handle internally the storage of the v4l2_fh instance under file->private_data, see [1], [2] and [3].

The file pointer associated with the v4l2_fh instaces is also stored under struct virtio_media_queue_state to facilitate calls to virtio_media_session_close() from the virtio_driver->remove() context where the file isn't readily available.

Link: https://git.kernel.org/torvalds/c/47f4b1acb4d5 [1]
Link: https://git.kernel.org/torvalds/c/277966749f46 [2]
Link: https://git.kernel.org/torvalds/c/618882c92681 [3]
[adelva: reworked against tot]