### PR TITLE
simple_device: Switch to YUV420 pixel format

### DIFF
--- a/device/src/devices/simple_device.rs
+++ b/device/src/devices/simple_device.rs
@@ -142,13 +142,18 @@ impl SimpleCaptureDeviceSession {
                 .seek(SeekFrom::Start(0))
                 .map_err(|_| libc::EIO)?;
             let mut writer = BufWriter::new(buffer.fd.as_file());
-            let color = [
-                0xffu8 * (sequence as u8 % 2),
-                0x55u8 * (sequence as u8 % 3),
-                0x10u8 * (sequence as u8 % 16),
-            ];
+            let y = (sequence % 256) as u8;
+            let u = ((sequence + 64) % 256) as u8;
+            let v = ((sequence + 128) % 256) as u8;
+
             for _ in 0..(WIDTH * HEIGHT) {
-                let _ = writer.write(&color).map_err(|_| libc::EIO)?;
+                writer.write_all(&[y]).map_err(|_| libc::EIO)?;
+            }
+            for _ in 0..(WIDTH * HEIGHT / 4) {
+                writer.write_all(&[u]).map_err(|_| libc::EIO)?;
+            }
+            for _ in 0..(WIDTH * HEIGHT / 4) {
+                writer.write_all(&[v]).map_err(|_| libc::EIO)?;
             }
             drop(writer);
 
@@ -275,11 +280,10 @@ where
     }
 }
 
-const PIXELFORMAT: u32 = PixelFormat::from_fourcc(b"RGB3").to_u32();
+const PIXELFORMAT: u32 = PixelFormat::from_fourcc(b"YU12").to_u32();
 const WIDTH: u32 = 640;
 const HEIGHT: u32 = 480;
-const BYTES_PER_LINE: u32 = WIDTH * 3;
-const BUFFER_SIZE: u32 = BYTES_PER_LINE * HEIGHT;
+const BUFFER_SIZE: u32 = WIDTH * HEIGHT * 3 / 2;
 
 const INPUTS: [bindings::v4l2_input; 1] = [bindings::v4l2_input {
     index: 0,
@@ -298,20 +302,41 @@ fn default_fmtdesc(queue: QueueType) -> v4l2_fmtdesc {
 }
 
 fn default_fmt(queue: QueueType) -> v4l2_format {
-    let pix = v4l2_pix_format {
+    let pix_mp = bindings::v4l2_pix_format_mplane {
         width: WIDTH,
         height: HEIGHT,
         pixelformat: PIXELFORMAT,
         field: bindings::v4l2_field_V4L2_FIELD_NONE,
-        bytesperline: BYTES_PER_LINE,
-        sizeimage: BUFFER_SIZE,
         colorspace: bindings::v4l2_colorspace_V4L2_COLORSPACE_SRGB,
+        num_planes: 3,
+        plane_fmt: [
+            bindings::v4l2_plane_pix_format {
+                sizeimage: WIDTH * HEIGHT,
+                bytesperline: WIDTH,
+                ..Default::default()
+            },
+            bindings::v4l2_plane_pix_format {
+                sizeimage: WIDTH * HEIGHT / 4,
+                bytesperline: WIDTH / 2,
+                ..Default::default()
+            },
+            bindings::v4l2_plane_pix_format {
+                sizeimage: WIDTH * HEIGHT / 4,
+                bytesperline: WIDTH / 2,
+                ..Default::default()
+            },
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+        ],
         ..Default::default()
     };
 
     v4l2_format {
         type_: queue as u32,
-        fmt: bindings::v4l2_format__bindgen_ty_1 { pix },
+        fmt: bindings::v4l2_format__bindgen_ty_1 { pix_mp },
     }
 }
 
@@ -329,7 +354,7 @@ where
         queue: QueueType,
         index: u32,
     ) -> IoctlResult<v4l2_fmtdesc> {
-        if queue != QueueType::VideoCapture {
+        if queue != QueueType::VideoCaptureMplane {
             return Err(libc::EINVAL);
         }
         if index > 0 {
@@ -340,10 +365,9 @@ where
     }
 
     fn g_fmt(&mut self, _session: &Self::Session, queue: QueueType) -> IoctlResult<v4l2_format> {
-        if queue != QueueType::VideoCapture {
+        if queue != QueueType::VideoCaptureMplane {
             return Err(libc::EINVAL);
         }
-
         Ok(default_fmt(queue))
     }
 
@@ -353,10 +377,9 @@ where
         queue: QueueType,
         _format: v4l2_format,
     ) -> IoctlResult<v4l2_format> {
-        if queue != QueueType::VideoCapture {
+        if queue != QueueType::VideoCaptureMplane {
             return Err(libc::EINVAL);
         }
-
         Ok(default_fmt(queue))
     }
 
@@ -366,10 +389,9 @@ where
         queue: QueueType,
         _format: v4l2_format,
     ) -> IoctlResult<v4l2_format> {
-        if queue != QueueType::VideoCapture {
+        if queue != QueueType::VideoCaptureMplane {
             return Err(libc::EINVAL);
         }
-
         Ok(default_fmt(queue))
     }
 
@@ -429,8 +451,7 @@ where
                             .register_buffer(None, BUFFER_SIZE)
                             .map_err(|_| libc::EINVAL)?;
 
-                        let mut v4l2_buffer =
-                            V4l2Buffer::new(QueueType::VideoCapture, i, MemoryType::Mmap);
+                        let mut v4l2_buffer = V4l2Buffer::new(queue, i, MemoryType::Mmap);
                         if let V4l2PlanesWithBackingMut::Mmap(mut planes) =
                             v4l2_buffer.planes_with_backing_iter_mut()
                         {
@@ -474,7 +495,7 @@ where
         queue: QueueType,
         index: u32,
     ) -> IoctlResult<v4l2r::ioctl::V4l2Buffer> {
-        if queue != QueueType::VideoCapture {
+        if queue != QueueType::VideoCaptureMplane {
             return Err(libc::EINVAL);
         }
         let buffer = session.buffers.get(index as usize).ok_or(libc::EINVAL)?;
@@ -510,7 +531,7 @@ where
     }
 
     fn streamon(&mut self, session: &mut Self::Session, queue: QueueType) -> IoctlResult<()> {
-        if queue != QueueType::VideoCapture || session.buffers.is_empty() {
+        if queue != QueueType::VideoCaptureMplane || session.buffers.is_empty() {
             return Err(libc::EINVAL);
         }
         session.streaming = true;
@@ -521,7 +542,7 @@ where
     }
 
     fn streamoff(&mut self, session: &mut Self::Session, queue: QueueType) -> IoctlResult<()> {
-        if queue != QueueType::VideoCapture {
+        if queue != QueueType::VideoCaptureMplane {
             return Err(libc::EINVAL);
         }
         session.streaming = false;


### PR DESCRIPTION
In practice, it is more common for a video capture device to support YUV420 than RGB888. So let's switch over to YUV420.

Test: `v4l2-compliance -d1 -s` passes 59/59
Test: `v4l2-ctl -d1 --info` shows
```
Driver Info:
	Driver name      : virtio_media
	Card type        : simple_device
	Bus info         : platform:virtio-media0
	Driver version   : 6.12.52
	Capabilities     : 0x84201000
		Video Capture Multiplanar
		Streaming
		Extended Pix Format
		Device Capabilities
	Device Caps      : 0x04201000
		Video Capture Multiplanar
		Streaming
		Extended Pix Format
```