### PR TITLE
V4 Patches

### DIFF
--- a/driver/protocol.h
+++ b/driver/protocol.h
@@ -152,20 +152,6 @@ struct virtio_media_sg_entry {
 	u32 __reserved;
 };
 
-/**
- * enum virtio_media_memory - Memory types supported by virtio-media.
- * @VIRTIO_MEDIA_MMAP: memory allocated and managed by device. Can be mapped
- * into the guest using VIRTIO_MEDIA_CMD_MMAP.
- * @VIRTIO_MEDIA_SHARED_PAGES: memory allocated by the driver. Passed to the
- * device using virtio_media_sg_entry.
- * @VIRTIO_MEDIA_OBJECT: memory backed by a virtio object.
- */
-enum virtio_media_memory {
-	VIRTIO_MEDIA_MMAP = V4L2_MEMORY_MMAP,
-	VIRTIO_MEDIA_SHARED_PAGES = V4L2_MEMORY_USERPTR,
-	VIRTIO_MEDIA_OBJECT = V4L2_MEMORY_DMABUF,
-};
-
 #define VIRTIO_MEDIA_MMAP_FLAG_RW BIT(0)
 
 /**

--- a/driver/protocol.h
+++ b/driver/protocol.h
@@ -10,6 +10,7 @@
 #define __VIRTIO_MEDIA_PROTOCOL_H
 
 #include <linux/videodev2.h>
+#include <linux/bits.h>
 
 /*
  * Virtio protocol definition.
@@ -62,7 +63,8 @@ struct virtio_media_cmd_open {
 /**
  * struct virtio_media_resp_open - Device response for VIRTIO_MEDIA_CMD_OPEN.
  * @hdr: header containing the status of the command.
- * @session_id: if hdr.status == 0, contains the id of the newly created session.
+ * @session_id: if hdr.status == 0, contains the id of the newly created
+ *              session.
  * @__reserved: must be set to zero by the device.
  */
 struct virtio_media_resp_open {
@@ -138,7 +140,8 @@ struct virtio_media_resp_ioctl {
 };
 
 /**
- * struct virtio_media_sg_entry - Description of part of a scattered guest memory.
+ * struct virtio_media_sg_entry - Description of part of a scattered guest
+ *                                memory.
  * @start: start guest address of the memory segment.
  * @len: length of this memory segment.
  * @__reserved: must be set to zero by the driver.
@@ -163,7 +166,7 @@ enum virtio_media_memory {
 	VIRTIO_MEDIA_OBJECT = V4L2_MEMORY_DMABUF,
 };
 
-#define VIRTIO_MEDIA_MMAP_FLAG_RW (1 << 0)
+#define VIRTIO_MEDIA_MMAP_FLAG_RW BIT(0)
 
 /**
  * VIRTIO_MEDIA_CMD_MMAP - Command for mapping a MMAP buffer into the driver's
@@ -177,7 +180,8 @@ enum virtio_media_memory {
  * @hdr: header with cmd member set to VIRTIO_MEDIA_CMD_MMAP.
  * @session_id: ID of the session we are mapping for.
  * @flags: combination of VIRTIO_MEDIA_MMAP_FLAG_*.
- * @offset: mem_offset field of the plane to map, as returned by VIDIOC_QUERYBUF.
+ * @offset: mem_offset field of the plane to map, as returned by
+ *          VIDIOC_QUERYBUF.
  */
 struct virtio_media_cmd_mmap {
 	struct virtio_media_cmd_header hdr;
@@ -207,7 +211,8 @@ struct virtio_media_resp_mmap {
 /**
  * struct virtio_media_cmd_munmap - Driver command for VIRTIO_MEDIA_CMD_MUNMAP.
  * @hdr: header with cmd member set to VIRTIO_MEDIA_CMD_MUNMAP.
- * @driver_addr: offset into SHM region 0 at which the buffer has been previously
+ * @driver_addr: offset into SHM region 0 at which the buffer has been
+ *               previously
  * mapped.
  */
 struct virtio_media_cmd_munmap {
@@ -216,7 +221,8 @@ struct virtio_media_cmd_munmap {
 };
 
 /**
- * struct virtio_media_resp_munmap - Device response for VIRTIO_MEDIA_CMD_MUNMAP.
+ * struct virtio_media_resp_munmap - Device response for
+ *                                   VIRTIO_MEDIA_CMD_MUNMAP.
  * @hdr: header containing the status of the command.
  */
 struct virtio_media_resp_munmap {
@@ -282,7 +288,9 @@ struct virtio_media_event_event {
 	struct v4l2_event event;
 };
 
-/* Maximum size of an event. We will queue descriptors of this size on the eventq. */
+/* Maximum size of an event. We will queue descriptors of this size on the
+ * eventq.
+ */
 #define VIRTIO_MEDIA_EVENT_MAX_SIZE sizeof(struct virtio_media_event_dqbuf)
 
 #endif // __VIRTIO_MEDIA_PROTOCOL_H

--- a/driver/protocol.h
+++ b/driver/protocol.h
@@ -229,6 +229,7 @@ struct virtio_media_resp_munmap {
 	struct virtio_media_resp_header hdr;
 };
 
+/* The values for these events are set by the virtio-media specification. */
 #define VIRTIO_MEDIA_EVT_ERROR 0
 #define VIRTIO_MEDIA_EVT_DQBUF 1
 #define VIRTIO_MEDIA_EVT_EVENT 2
@@ -259,6 +260,10 @@ struct virtio_media_event_error {
 	u32 __reserved;
 };
 
+/* This is set to VIDEO_MAX_PLANES defined in include/uapi/linux/videodev2.h.
+ * It is renamed here to match the constant that is defined in the virtio-media
+ * specification.
+ */
 #define VIRTIO_MEDIA_MAX_PLANES VIDEO_MAX_PLANES
 
 /**

--- a/driver/scatterlist_builder.c
+++ b/driver/scatterlist_builder.c
@@ -24,7 +24,7 @@ static bool always_use_shadow_buffer;
 module_param(always_use_shadow_buffer, bool, 0660);
 
 /* Convert a V4L2 IOCTL into the IOCTL code we can give to the host */
-#define VIRTIO_MEDIA_IOCTL_CODE(IOCTL) ((IOCTL >> _IOC_NRSHIFT) & _IOC_NRMASK)
+#define VIRTIO_MEDIA_IOCTL_CODE(IOCTL) (((IOCTL) >> _IOC_NRSHIFT) & _IOC_NRMASK)
 
 /**
  * scatterlist_builder_add_descriptor() - Add a descriptor to the chain.
@@ -44,7 +44,8 @@ int scatterlist_builder_add_descriptor(struct scatterlist_builder *builder,
 }
 
 /**
- * scatterlist_builder_add_data() - Append arbitrary data to the descriptor chain.
+ * scatterlist_builder_add_data() - Append arbitrary data to the descriptor
+ *                                  chain.
  * @builder: builder to use.
  * @data: pointer to the data to add to the descriptor chain.
  * @len: length of the data to add.
@@ -409,9 +410,13 @@ int scatterlist_builder_add_buffer_userptr(struct scatterlist_builder *builder,
 
 			if (b->memory == V4L2_MEMORY_USERPTR &&
 			    plane->length > 0) {
-				ret = scatterlist_builder_add_userptr(
-					builder, plane->m.userptr,
-					plane->length);
+				unsigned long uptr = plane->m.userptr;
+				unsigned long len = plane->length;
+
+				ret =
+				scatterlist_builder_add_userptr(builder,
+								uptr,
+								len);
 				if (ret)
 					return ret;
 			}
@@ -457,9 +462,10 @@ int scatterlist_builder_retrieve_buffer(struct scatterlist_builder *builder,
 	if (V4L2_TYPE_IS_MULTIPLANAR(b->type)) {
 		b->m.planes = orig_planes;
 
-		if (orig_planes != NULL) {
-			ret = scatterlist_builder_retrieve_data(
-				builder, sg_index++, b->m.planes);
+		if (orig_planes) {
+			ret = scatterlist_builder_retrieve_data(builder,
+								sg_index++,
+								b->m.planes);
 			if (ret)
 				return ret;
 		}
@@ -474,7 +480,8 @@ int scatterlist_builder_retrieve_buffer(struct scatterlist_builder *builder,
  * @builder: builder to use.
  * @ctrls: ``struct v4l2_ext_controls`` to add.
  *
- * Add @ctrls and its array of `struct v4l2_ext_control` to the descriptor chain.
+ * Add @ctrls and its array of `struct v4l2_ext_control` to the descriptor
+ * chain.
  */
 int scatterlist_builder_add_ext_ctrls(struct scatterlist_builder *builder,
 				      struct v4l2_ext_controls *ctrls)
@@ -502,14 +509,16 @@ int scatterlist_builder_add_ext_ctrls(struct scatterlist_builder *builder,
  * scatterlist_builder_add_ext_ctrls_userptrs() - Add the userspace payloads of
  * a ``struct v4l2_ext_controls`` to the descriptor chain.
  * @builder: builder to use.
- * @ctrls: ``struct v4l2_ext_controls`` from which we want to add the userspace payload of.
+ * @ctrls: ``struct v4l2_ext_controls`` from which we want to add the
+ *         userspace payload of.
  *
  * Add the userspace payloads of @ctrls to the descriptor chain. This is split
  * out of :ref:`scatterlist_builder_add_ext_ctrls` because we only want to add
  * these to the device-readable part of the descriptor chain.
  */
-int scatterlist_builder_add_ext_ctrls_userptrs(
-	struct scatterlist_builder *builder, struct v4l2_ext_controls *ctrls)
+int
+scatterlist_builder_add_ext_ctrls_userptrs(struct scatterlist_builder *builder,
+					   struct v4l2_ext_controls *ctrls)
 {
 	int i;
 	int ret;
@@ -519,8 +528,10 @@ int scatterlist_builder_add_ext_ctrls_userptrs(
 		struct v4l2_ext_control *ctrl = &ctrls->controls[i];
 
 		if (ctrl->size > 0) {
-			ret = scatterlist_builder_add_userptr(
-				builder, (unsigned long)ctrl->ptr, ctrl->size);
+			unsigned long uptr = (unsigned long)ctrl->ptr;
+
+			ret = scatterlist_builder_add_userptr(builder, uptr,
+							      ctrl->size);
 			if (ret)
 				return ret;
 		}

--- a/driver/scatterlist_builder.h
+++ b/driver/scatterlist_builder.h
@@ -101,8 +101,9 @@ int scatterlist_builder_retrieve_buffer(struct scatterlist_builder *builder,
 int scatterlist_builder_add_ext_ctrls(struct scatterlist_builder *builder,
 				      struct v4l2_ext_controls *ctrls);
 
-int scatterlist_builder_add_ext_ctrls_userptrs(
-	struct scatterlist_builder *builder, struct v4l2_ext_controls *ctrls);
+int
+scatterlist_builder_add_ext_ctrls_userptrs(struct scatterlist_builder *builder,
+					   struct v4l2_ext_controls *ctrls);
 
 int scatterlist_builder_retrieve_ext_ctrls(struct scatterlist_builder *builder,
 					   size_t sg_index,

--- a/driver/session.h
+++ b/driver/session.h
@@ -63,13 +63,18 @@ struct virtio_media_queue_state {
  * @nonblocking_dequeue: whether dequeue should block or not (nonblocking if
  * file opened with O_NONBLOCK).
  * @uses_mplane: whether the queues for this session use the MPLANE API or not.
- * @cmd: union of session-related commands. A session can have one command currently running.
- * @resp: union of session-related responses. A session can wait on one command only.
+ * @cmd: union of session commands "close", "ioctl", and "mmap". A session can
+ *       have one command currently running. The rest of the commands are
+ *       handled by @struct virtio_media.
+ * @resp: union of responses to session commands "close", "ioctl", and "mmap".
+ *        A session can wait on one command only.The rest of the responses are
+ *        handled by @struct virtio_media.
  * @shadow_buf: shadow buffer where data to be added to the descriptor chain can
  * be staged before being sent to the device.
- * @command_sgs: SG table gathering descriptors for a given command and its response.
+ * @command_sgs: SG table gathering descriptors for a given command and its
+ *               response.
  * @queues: state of all the queues for this session.
- * @queues_lock: protects all members fo the queues for this session.
+ * @queues_lock: protects all members for the queues for this session.
  * virtio_media_queue_state`.
  * @dqbuf_wait: waitqueue for dequeued buffers, if ``VIDIOC_DQBUF`` needs to
  * block or when polling.

--- a/driver/session.h
+++ b/driver/session.h
@@ -77,7 +77,7 @@ struct virtio_media_queue_state {
  */
 struct virtio_media_session {
 	struct v4l2_fh fh;
-        struct file *file;
+	struct file *file;
 	u32 id;
 	bool nonblocking_dequeue;
 	bool uses_mplane;
@@ -98,7 +98,7 @@ struct virtio_media_session {
 	struct sg_table command_sgs;
 
 	struct virtio_media_queue_state queues[VIRTIO_MEDIA_LAST_QUEUE + 1];
-	struct mutex queues_lock;
+	struct mutex queues_lock; /* protects queues array and states */
 	wait_queue_head_t dqbuf_wait;
 
 	struct list_head list;

--- a/driver/virtio_media.h
+++ b/driver/virtio_media.h
@@ -34,8 +34,10 @@ extern bool virtio_media_allow_userptr;
  * @sessions: list of active sessions on the device.
  * @sessions_lock: protects @sessions and ``virtio_media_session::list``.
  * @events_lock: prevents concurrent processing of events.
- * @cmd: union of device-related commands.
- * @resp: union of device-related responses.
+ * @cmd: union of the device commands "open" and "munmap". The other
+ *       commands are handled by @struct virtio_media_session
+ * @resp: union of responses.to device commands "open" and "munmap". The
+ *        other responses are handled by @struct virtio_media_session
  * @vlock: serializes access to the command queue.
  * @wq: waitqueue for host responses on the command queue.
  */

--- a/driver/virtio_media.h
+++ b/driver/virtio_media.h
@@ -53,9 +53,9 @@ struct virtio_media {
 	void *event_buffer;
 
 	struct list_head sessions;
-	struct mutex sessions_lock;
+	struct mutex sessions_lock; /* protects sessions list */
 
-	struct mutex events_lock;
+	struct mutex events_lock; /* prevents concurrent event processing */
 
 	union {
 		struct virtio_media_cmd_open open;
@@ -67,7 +67,7 @@ struct virtio_media {
 		struct virtio_media_resp_munmap munmap;
 	} resp;
 
-	struct mutex vlock;
+	struct mutex vlock; /* serializes command queue access */
 	wait_queue_head_t wq;
 };
 

--- a/driver/virtio_media_driver.c
+++ b/driver/virtio_media_driver.c
@@ -209,7 +209,8 @@ virtio_media_find_session(struct virtio_media *vv, u32 id)
 }
 
 /**
- * struct virtio_media_cmd_callback_param - Callback parameters to the virtio command queue.
+ * struct virtio_media_cmd_callback_param - Callback parameters to the virtio
+ *                                          command queue.
  * @vv: virtio-media device in use.
  * @done: flag to be switched once the command is completed.
  * @resp_len: length of the received response from the command. Only valid
@@ -335,16 +336,18 @@ int virtio_media_send_command(struct virtio_media *vv, struct scatterlist **sgs,
 	if (resp_len)
 		*resp_len = local_resp_len;
 
-	/* If the host could not process the command, there is no valid response */
+	/*
+	 * If the host could not process the command, there is no valid
+	 * response.
+	 */
 	if (ret < 0)
 		return ret;
 
 	/* Make sure the host wrote a complete reply. */
 	if (local_resp_len < minimum_resp_len) {
-		v4l2_err(
-			&vv->v4l2_dev,
-			"received response is too short: received %zu, expected at least %zu\n",
-			local_resp_len, minimum_resp_len);
+		v4l2_err(&vv->v4l2_dev,
+			 "received response is too short: received %zu, expected at least %zu\n",
+			 local_resp_len, minimum_resp_len);
 		return -EINVAL;
 	}
 
@@ -441,9 +444,8 @@ virtio_media_process_dqbuf_event(struct virtio_media *vv,
 	dqbuf->buffer.m = buffer_m;
 	if (V4L2_TYPE_IS_MULTIPLANAR(dqbuf->buffer.type)) {
 		if (dqbuf->buffer.length > VIDEO_MAX_PLANES) {
-			v4l2_err(
-				&vv->v4l2_dev,
-				"invalid number of planes received from host for a multiplanar buffer\n");
+			v4l2_err(&vv->v4l2_dev,
+				 "invalid number of planes received from host for a multiplanar buffer\n");
 			return;
 		}
 		for (i = 0; i < dqbuf->buffer.length; i++) {
@@ -489,10 +491,9 @@ process_bufs:
 	while ((evt = virtqueue_get_buf(vv->eventq, &len))) {
 		/* Make sure we received enough data */
 		if (len < sizeof(*evt)) {
-			v4l2_err(
-				&vv->v4l2_dev,
-				"event is too short: got %u, expected at least %zu\n",
-				len, sizeof(*evt));
+			v4l2_err(&vv->v4l2_dev,
+				 "event is too short: got %u, expected at least %zu\n",
+				 len, sizeof(*evt));
 			goto end_of_event;
 		}
 
@@ -506,10 +507,9 @@ process_bufs:
 		switch (evt->event) {
 		case VIRTIO_MEDIA_EVT_ERROR:
 			if (len < sizeof(*error_evt)) {
-				v4l2_err(
-					&vv->v4l2_dev,
-					"error event is too short: got %u, expected %zu\n",
-					len, sizeof(*error_evt));
+				v4l2_err(&vv->v4l2_dev,
+					 "error event is too short: got %u, expected %zu\n",
+					 len, sizeof(*error_evt));
 				break;
 			}
 			error_evt = (struct virtio_media_event_error *)evt;
@@ -520,15 +520,14 @@ process_bufs:
 			break;
 
 		/*
-		 * Dequeued buffer: put it into the right queue so user-space can dequeue
-		 * it.
+		 * Dequeued buffer: put it into the right queue so user-space
+		 * can dequeue it.
 		 */
 		case VIRTIO_MEDIA_EVT_DQBUF:
 			if (len < sizeof(*dqbuf_evt)) {
-				v4l2_err(
-					&vv->v4l2_dev,
-					"dqbuf event is too short: got %u, expected %zu\n",
-					len, sizeof(*dqbuf_evt));
+				v4l2_err(&vv->v4l2_dev,
+					 "dqbuf event is too short: got %u, expected %zu\n",
+					 len, sizeof(*dqbuf_evt));
 				break;
 			}
 			dqbuf_evt = (struct virtio_media_event_dqbuf *)evt;
@@ -538,10 +537,9 @@ process_bufs:
 
 		case VIRTIO_MEDIA_EVT_EVENT:
 			if (len < sizeof(*event_evt)) {
-				v4l2_err(
-					&vv->v4l2_dev,
-					"session event is too short: got %u expected %zu\n",
-					len, sizeof(*event_evt));
+				v4l2_err(&vv->v4l2_dev,
+					 "session event is too short: got %u expected %zu\n",
+					 len, sizeof(*event_evt));
 				break;
 			}
 
@@ -769,8 +767,9 @@ static int virtio_media_device_mmap(struct file *file,
 	sg_mark_end(&resp_sg);
 
 	/*
-	 * The host performs reference counting and is smart enough to return the
-	 * same guest physical address if this is called several times on the same
+	 * The host performs reference counting and is smart enough to return
+	 * the same guest physical address if this is called several times on
+	 * the same
 	 * buffer.
 	 */
 	ret = virtio_media_send_command(vv, sgs, 1, 1, sizeof(*resp_mmap),
@@ -850,9 +849,10 @@ static int virtio_media_probe(struct virtio_device *virtio_dev)
 	if (!vv)
 		return -ENOMEM;
 
-	vv->event_buffer = devm_kzalloc(
-		dev, VIRTIO_MEDIA_EVENT_MAX_SIZE * VIRTIO_MEDIA_NUM_EVENT_BUFS,
-		GFP_KERNEL);
+	vv->event_buffer = devm_kzalloc(dev,
+					VIRTIO_MEDIA_EVENT_MAX_SIZE *
+					VIRTIO_MEDIA_NUM_EVENT_BUFS,
+					GFP_KERNEL);
 	if (!vv->event_buffer)
 		return -ENOMEM;
 
@@ -910,8 +910,9 @@ static int virtio_media_probe(struct virtio_device *virtio_dev)
 		goto err_register_device;
 
 	for (i = 0; i < VIRTIO_MEDIA_NUM_EVENT_BUFS; i++) {
-		ret = virtio_media_send_event_buffer(
-			vv, vv->event_buffer + VIRTIO_MEDIA_EVENT_MAX_SIZE * i);
+		void *ebuf = vv->event_buffer + VIRTIO_MEDIA_EVENT_MAX_SIZE * i;
+
+		ret = virtio_media_send_event_buffer(vv, ebuf);
 		if (ret)
 			goto err_send_event_buffer;
 	}

--- a/driver/virtio_media_ioctls.c
+++ b/driver/virtio_media_ioctls.c
@@ -520,9 +520,11 @@ SIMPLE_WR_IOCTL(enum_framesizes, VIDIOC_ENUM_FRAMESIZES,
 		struct v4l2_frmsizeenum)
 SIMPLE_WR_IOCTL(enum_frameintervals, VIDIOC_ENUM_FRAMEINTERVALS,
 		struct v4l2_frmivalenum)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 15, 0)
 SIMPLE_WR_IOCTL(queryctrl, VIDIOC_QUERYCTRL, struct v4l2_queryctrl)
 SIMPLE_WR_IOCTL(g_ctrl, VIDIOC_G_CTRL, struct v4l2_control)
 SIMPLE_WR_IOCTL(s_ctrl, VIDIOC_S_CTRL, struct v4l2_control)
+#endif
 SIMPLE_WR_IOCTL(query_ext_ctrl, VIDIOC_QUERY_EXT_CTRL,
 		struct v4l2_query_ext_ctrl)
 SIMPLE_WR_IOCTL(s_dv_timings, VIDIOC_S_DV_TIMINGS, struct v4l2_dv_timings)
@@ -1207,10 +1209,12 @@ const struct v4l2_ioctl_ops virtio_media_ioctl_ops = {
 	.vidioc_s_output = virtio_media_s_output,
 
 	/* Control handling */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 15, 0)
 	.vidioc_queryctrl = virtio_media_queryctrl,
-	.vidioc_query_ext_ctrl = virtio_media_query_ext_ctrl,
 	.vidioc_g_ctrl = virtio_media_g_ctrl,
 	.vidioc_s_ctrl = virtio_media_s_ctrl,
+#endif
+	.vidioc_query_ext_ctrl = virtio_media_query_ext_ctrl,
 	.vidioc_g_ext_ctrls = virtio_media_g_ext_ctrls,
 	.vidioc_s_ext_ctrls = virtio_media_s_ext_ctrls,
 	.vidioc_try_ext_ctrls = virtio_media_try_ext_ctrls,

--- a/driver/virtio_media_ioctls.c
+++ b/driver/virtio_media_ioctls.c
@@ -65,9 +65,9 @@ static int virtio_media_send_r_ioctl(struct v4l2_fh *fh, u32 ioctl,
 		return ret;
 	}
 
-	ret = virtio_media_send_command(
-		vv, sgs, 1, 2,
-		sizeof(struct virtio_media_resp_ioctl) + ioctl_data_len, NULL);
+	ret = virtio_media_send_command(vv, sgs, 1, 2,
+					sizeof(struct virtio_media_resp_ioctl) +
+					ioctl_data_len, NULL);
 	if (ret < 0)
 		return ret;
 
@@ -131,8 +131,9 @@ static int virtio_media_send_w_ioctl(struct v4l2_fh *fh, u32 ioctl,
 	if (ret)
 		return ret;
 
-	ret = virtio_media_send_command(
-		vv, sgs, 2, 1, sizeof(struct virtio_media_resp_ioctl), NULL);
+	ret = virtio_media_send_command(vv, sgs, 2, 1,
+					sizeof(struct virtio_media_resp_ioctl),
+					NULL);
 	if (ret < 0)
 		return ret;
 
@@ -234,7 +235,10 @@ static int virtio_media_send_buffer_ioctl(struct v4l2_fh *fh, u32 ioctl,
 	struct virtio_media_session *session = fh_to_session(fh);
 	struct v4l2_plane *orig_planes = NULL;
 	struct scatterlist *sgs[64];
-	/* End of the device-readable buffer SGs, to reuse in device-writable section. */
+	/*
+	 * End of the device-readable buffer SGs, to reuse in device-writable
+	 * section.
+	 */
 	size_t num_cmd_sgs;
 	size_t end_buf_sg;
 	struct scatterlist_builder builder = {
@@ -289,9 +293,10 @@ static int virtio_media_send_buffer_ioctl(struct v4l2_fh *fh, u32 ioctl,
 			return ret;
 	}
 
-	ret = virtio_media_send_command(
-		vv, builder.sgs, num_cmd_sgs, builder.cur_sg - num_cmd_sgs,
-		sizeof(struct virtio_media_resp_ioctl) + sizeof(*b), &resp_len);
+	ret = virtio_media_send_command(vv, builder.sgs, num_cmd_sgs,
+					builder.cur_sg - num_cmd_sgs,
+					sizeof(struct virtio_media_resp_ioctl) +
+					sizeof(*b), &resp_len);
 	if (ret < 0)
 		return ret;
 
@@ -382,25 +387,31 @@ static int virtio_media_send_ext_controls_ioctl(struct v4l2_fh *fh, u32 ioctl,
 			return ret;
 	}
 
-	ret = virtio_media_send_command(
-		vv, builder.sgs, num_cmd_sgs, builder.cur_sg - num_cmd_sgs,
-		sizeof(struct virtio_media_resp_ioctl) + sizeof(*ctrls),
-		&resp_len);
+	ret = virtio_media_send_command(vv, builder.sgs, num_cmd_sgs,
+					builder.cur_sg - num_cmd_sgs,
+					sizeof(struct virtio_media_resp_ioctl) +
+					sizeof(*ctrls),
+					&resp_len);
 
 	/* Just in case the host touched these. */
 	ctrls->controls = controls_backup;
 	if (ctrls->count != num_ctrls) {
-		v4l2_err(
-			&vv->v4l2_dev,
-			"device returned a number of controls different than the one submitted\n");
+		v4l2_err(&vv->v4l2_dev,
+			 "device returned a number of controls different than the one submitted\n");
 	}
 	if (ctrls->count > num_ctrls)
 		return -ENOSPC;
 
-	/* Event if we have received an error, we may need to read our payload back */
+	/*
+	 * Event if we have received an error, we may need to read our payload
+	 * back.
+	 */
 	if (ret < 0 && resp_len >= sizeof(struct virtio_media_resp_ioctl) +
 					   sizeof(*ctrls)) {
-		/* Deliberately ignore the error here as we want to return the previous one */
+		/*
+		 * Deliberately ignore the error here as we want to return the
+		 * previous one.
+		 */
 		scatterlist_builder_retrieve_ext_ctrls(&builder,
 						       num_cmd_sgs + 1, ctrls);
 		return ret;
@@ -421,7 +432,8 @@ static int virtio_media_send_ext_controls_ioctl(struct v4l2_fh *fh, u32 ioctl,
 }
 
 /**
- * virtio_media_clear_queue() - clear all pending buffers on a streamed-off queue.
+ * virtio_media_clear_queue() - clear all pending buffers on a streamed-off
+ *                              queue.
  * @session: session which the queue to clear belongs to.
  * @queue: state of the queue to clear.
  *
@@ -630,7 +642,8 @@ virtio_media_subscribe_event(struct v4l2_fh *fh,
 
 	/*
 	 * Subscribing to an event may result in that event being signaled
-	 * immediately. Process all pending events to make sure we don't miss it.
+	 * immediately. Process all pending events to make sure we don't
+	 * miss it.
 	 */
 	if (sub->flags & V4L2_EVENT_SUB_FL_SEND_INITIAL)
 		virtio_media_process_events(vv);
@@ -772,7 +785,10 @@ static int virtio_media_querybuf(struct file *file, void *fh,
 		return -EINVAL;
 
 	buffer = &queue->buffers[b->index];
-	/* Set the DONE flag if the buffer is waiting in our own dequeue queue. */
+	/*
+	 * Set the DONE flag if the buffer is waiting in our own dequeue
+	 * queue.
+	 */
 	b->flags |= (buffer->buffer.flags & V4L2_BUF_FLAG_DONE);
 
 	return 0;
@@ -869,8 +885,8 @@ static int virtio_media_qbuf(struct file *file, void *fh, struct v4l2_buffer *b)
 	prepared = buffer->buffer.flags & V4L2_BUF_FLAG_PREPARED;
 
 	/*
-	 * Store the buffer and plane `m` information so we can retrieve it again
-	 * when DQBUF occurs.
+	 * Store the buffer and plane `m` information so we can retrieve
+	 * it again when DQBUF occurs.
 	 */
 	if (!prepared) {
 		buffer->buffer.m = b->m;
@@ -916,8 +932,8 @@ static int virtio_media_dqbuf(struct file *file, void *fh,
 	queue = &session->queues[b->type];
 
 	/*
-	 * If a buffer with the LAST flag has been returned, subsequent calls to DQBUF
-	 * must return -EPIPE until the queue is cleared.
+	 * If a buffer with the LAST flag has been returned, subsequent
+	 * calls to DQBUF must return -EPIPE until the queue is cleared.
 	 */
 	if (queue->is_capture_last)
 		return -EPIPE;
@@ -1183,7 +1199,10 @@ const struct v4l2_ioctl_ops virtio_media_ioctl_ops = {
 	.vidioc_s_modulator = virtio_media_s_modulator,
 
 	/* Crop ioctls */
-	/* Not directly an ioctl (part of VIDIOC_CROPCAP), so no need to implement */
+	/*
+	 * Not directly an ioctl (part of VIDIOC_CROPCAP), so no need to
+	 * implement.
+	 */
 	.vidioc_g_pixelaspect = NULL,
 	.vidioc_g_selection = virtio_media_g_selection,
 	.vidioc_s_selection = virtio_media_s_selection,
@@ -1249,15 +1268,15 @@ long virtio_media_device_ioctl(struct file *file, unsigned int cmd,
 	int ret;
 
 	if (test_bit(V4L2_FL_USES_V4L2_FH, &video_dev->flags))
-		vfh = file->private_data;
+		vfh = file_to_v4l2_fh(file);
 
 	mutex_lock(&vv->vlock);
 
 	/*
-	 * We need to handle a few ioctls manually because their result rely on
-	 * vfd->tvnorms, which is normally updated by the driver as S_INPUT is
-	 * called. Since we want to just pass these ioctls through, we have to hijack
-	 * them from here.
+	 * We need to handle a few ioctls manually because their result
+	 * rely on vfd->tvnorms, which is normally updated by the driver
+	 * as S_INPUT is called. Since we want to just pass these ioctls
+	 * through, we have to hijack them from here.
 	 */
 	switch (cmd) {
 	case VIDIOC_S_STD:

--- a/driver/virtio_media_ioctls.c
+++ b/driver/virtio_media_ioctls.c
@@ -7,6 +7,7 @@
  */
 
 #include <linux/mutex.h>
+#include <linux/version.h>
 #include <linux/videodev2.h>
 #include <linux/virtio_config.h>
 #include <linux/vmalloc.h>
@@ -15,6 +16,13 @@
 
 #include "scatterlist_builder.h"
 #include "virtio_media.h"
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 18, 0)
+static inline struct v4l2_fh *file_to_v4l2_fh(struct file *filp)
+{
+	return filp->private_data;
+}
+#endif
 
 /**
  * virtio_media_send_r_ioctl() - Send a read-only ioctl to the device.
@@ -474,7 +482,8 @@ static void virtio_media_clear_queue(struct virtio_media_session *session,
 	static int virtio_media_##name(struct file *file, void *fh,   \
 				       payload_t *payload)            \
 	{                                                             \
-		return virtio_media_send_wr_ioctl(fh, ioctl, payload, \
+		struct v4l2_fh *vfh = file_to_v4l2_fh(file);          \
+		return virtio_media_send_wr_ioctl(vfh, ioctl, payload,\
 						  sizeof(*payload),   \
 						  sizeof(*payload));  \
 	}
@@ -482,14 +491,16 @@ static void virtio_media_clear_queue(struct virtio_media_session *session,
 	static int virtio_media_##name(struct file *file, void *fh,  \
 				       payload_t *payload)           \
 	{                                                            \
-		return virtio_media_send_r_ioctl(fh, ioctl, payload, \
+		struct v4l2_fh *vfh = file_to_v4l2_fh(file);         \
+		return virtio_media_send_r_ioctl(vfh, ioctl, payload,\
 						 sizeof(*payload));  \
 	}
 #define SIMPLE_W_IOCTL(name, ioctl, payload_t)                       \
 	static int virtio_media_##name(struct file *file, void *fh,  \
 				       payload_t *payload)           \
 	{                                                            \
-		return virtio_media_send_w_ioctl(fh, ioctl, payload, \
+		struct v4l2_fh *vfh = file_to_v4l2_fh(file);         \
+		return virtio_media_send_w_ioctl(vfh, ioctl, payload,\
 						 sizeof(*payload));  \
 	}
 
@@ -590,21 +601,27 @@ static int virtio_media_querycap(struct file *file, void *fh,
 static int virtio_media_g_ext_ctrls(struct file *file, void *fh,
 				    struct v4l2_ext_controls *ctrls)
 {
-	return virtio_media_send_ext_controls_ioctl(fh, VIDIOC_G_EXT_CTRLS,
+	struct v4l2_fh *vfh = file_to_v4l2_fh(file);
+
+	return virtio_media_send_ext_controls_ioctl(vfh, VIDIOC_G_EXT_CTRLS,
 						    ctrls);
 }
 
 static int virtio_media_s_ext_ctrls(struct file *file, void *fh,
 				    struct v4l2_ext_controls *ctrls)
 {
-	return virtio_media_send_ext_controls_ioctl(fh, VIDIOC_S_EXT_CTRLS,
+	struct v4l2_fh *vfh = file_to_v4l2_fh(file);
+
+	return virtio_media_send_ext_controls_ioctl(vfh, VIDIOC_S_EXT_CTRLS,
 						    ctrls);
 }
 
 static int virtio_media_try_ext_ctrls(struct file *file, void *fh,
 				      struct v4l2_ext_controls *ctrls)
 {
-	return virtio_media_send_ext_controls_ioctl(fh, VIDIOC_TRY_EXT_CTRLS,
+	struct v4l2_fh *vfh = file_to_v4l2_fh(file);
+
+	return virtio_media_send_ext_controls_ioctl(vfh, VIDIOC_TRY_EXT_CTRLS,
 						    ctrls);
 }
 
@@ -676,13 +693,14 @@ virtio_media_unsubscribe_event(struct v4l2_fh *fh,
 static int virtio_media_streamon(struct file *file, void *fh,
 				 enum v4l2_buf_type i)
 {
-	struct virtio_media_session *session = fh_to_session(fh);
+	struct v4l2_fh *vfh = file_to_v4l2_fh(file);
+	struct virtio_media_session *session = fh_to_session(vfh);
 	int ret;
 
 	if (i > VIRTIO_MEDIA_LAST_QUEUE)
 		return -EINVAL;
 
-	ret = virtio_media_send_w_ioctl(fh, VIDIOC_STREAMON, &i, sizeof(i));
+	ret = virtio_media_send_w_ioctl(vfh, VIDIOC_STREAMON, &i, sizeof(i));
 	if (ret < 0)
 		return ret;
 
@@ -694,13 +712,14 @@ static int virtio_media_streamon(struct file *file, void *fh,
 static int virtio_media_streamoff(struct file *file, void *fh,
 				  enum v4l2_buf_type i)
 {
-	struct virtio_media_session *session = fh_to_session(fh);
+	struct v4l2_fh *vfh = file_to_v4l2_fh(file);
+	struct virtio_media_session *session = fh_to_session(vfh);
 	int ret;
 
 	if (i > VIRTIO_MEDIA_LAST_QUEUE)
 		return -EINVAL;
 
-	ret = virtio_media_send_w_ioctl(fh, VIDIOC_STREAMOFF, &i, sizeof(i));
+	ret = virtio_media_send_w_ioctl(vfh, VIDIOC_STREAMOFF, &i, sizeof(i));
 	if (ret < 0)
 		return ret;
 
@@ -716,7 +735,8 @@ static int virtio_media_streamoff(struct file *file, void *fh,
 static int virtio_media_reqbufs(struct file *file, void *fh,
 				struct v4l2_requestbuffers *b)
 {
-	struct virtio_media_session *session = fh_to_session(fh);
+	struct v4l2_fh *vfh = file_to_v4l2_fh(file);
+	struct virtio_media_session *session = fh_to_session(vfh);
 	struct virtio_media_queue_state *queue;
 	int ret;
 
@@ -726,7 +746,7 @@ static int virtio_media_reqbufs(struct file *file, void *fh,
 	if (b->memory == V4L2_MEMORY_USERPTR && !virtio_media_allow_userptr)
 		return -EINVAL;
 
-	ret = virtio_media_send_wr_ioctl(fh, VIDIOC_REQBUFS, b, sizeof(*b),
+	ret = virtio_media_send_wr_ioctl(vfh, VIDIOC_REQBUFS, b, sizeof(*b),
 					 sizeof(*b));
 	if (ret)
 		return ret;
@@ -768,12 +788,13 @@ static int virtio_media_reqbufs(struct file *file, void *fh,
 static int virtio_media_querybuf(struct file *file, void *fh,
 				 struct v4l2_buffer *b)
 {
-	struct virtio_media_session *session = fh_to_session(fh);
+	struct v4l2_fh *vfh = file_to_v4l2_fh(file);
+	struct virtio_media_session *session = fh_to_session(vfh);
 	struct virtio_media_queue_state *queue;
 	struct virtio_media_buffer *buffer;
 	int ret;
 
-	ret = virtio_media_send_buffer_ioctl(fh, VIDIOC_QUERYBUF, b);
+	ret = virtio_media_send_buffer_ioctl(vfh, VIDIOC_QUERYBUF, b);
 	if (ret)
 		return ret;
 
@@ -797,7 +818,8 @@ static int virtio_media_querybuf(struct file *file, void *fh,
 static int virtio_media_create_bufs(struct file *file, void *fh,
 				    struct v4l2_create_buffers *b)
 {
-	struct virtio_media_session *session = fh_to_session(fh);
+	struct v4l2_fh *vfh = file_to_v4l2_fh(file);
+	struct virtio_media_session *session = fh_to_session(vfh);
 	struct virtio_media_queue_state *queue;
 	struct virtio_media_buffer *buffers;
 	u32 type = b->format.type;
@@ -808,7 +830,7 @@ static int virtio_media_create_bufs(struct file *file, void *fh,
 
 	queue = &session->queues[type];
 
-	ret = virtio_media_send_wr_ioctl(fh, VIDIOC_CREATE_BUFS, b, sizeof(*b),
+	ret = virtio_media_send_wr_ioctl(vfh, VIDIOC_CREATE_BUFS, b, sizeof(*b),
 					 sizeof(*b));
 	if (ret)
 		return ret;
@@ -838,7 +860,8 @@ static int virtio_media_create_bufs(struct file *file, void *fh,
 static int virtio_media_prepare_buf(struct file *file, void *fh,
 				    struct v4l2_buffer *b)
 {
-	struct virtio_media_session *session = fh_to_session(fh);
+	struct v4l2_fh *vfh = file_to_v4l2_fh(file);
+	struct virtio_media_session *session = fh_to_session(vfh);
 	struct virtio_media_queue_state *queue;
 	struct virtio_media_buffer *buffer;
 	int i, ret;
@@ -858,7 +881,7 @@ static int virtio_media_prepare_buf(struct file *file, void *fh,
 			buffer->planes[i].m = b->m.planes[i].m;
 	}
 
-	ret = virtio_media_send_buffer_ioctl(fh, VIDIOC_PREPARE_BUF, b);
+	ret = virtio_media_send_buffer_ioctl(vfh, VIDIOC_PREPARE_BUF, b);
 	if (ret)
 		return ret;
 
@@ -869,7 +892,8 @@ static int virtio_media_prepare_buf(struct file *file, void *fh,
 
 static int virtio_media_qbuf(struct file *file, void *fh, struct v4l2_buffer *b)
 {
-	struct virtio_media_session *session = fh_to_session(fh);
+	struct v4l2_fh *vfh = file_to_v4l2_fh(file);
+	struct virtio_media_session *session = fh_to_session(vfh);
 	struct virtio_media_queue_state *queue;
 	struct virtio_media_buffer *buffer;
 	bool prepared;
@@ -900,7 +924,7 @@ static int virtio_media_qbuf(struct file *file, void *fh, struct v4l2_buffer *b)
 	old_flags = buffer->buffer.flags;
 	buffer->buffer.flags = V4L2_BUF_FLAG_QUEUED;
 
-	ret = virtio_media_send_buffer_ioctl(fh, VIDIOC_QBUF, b);
+	ret = virtio_media_send_buffer_ioctl(vfh, VIDIOC_QBUF, b);
 	if (ret) {
 		/* Rollback the previous flags as the buffer is not queued. */
 		buffer->buffer.flags = old_flags;
@@ -918,7 +942,7 @@ static int virtio_media_dqbuf(struct file *file, void *fh,
 	struct video_device *video_dev = video_devdata(file);
 	struct virtio_media *vv = to_virtio_media(video_dev);
 	struct virtio_media_session *session =
-		fh_to_session(file->private_data);
+		fh_to_session(file_to_v4l2_fh(file));
 	struct virtio_media_buffer *dqbuf;
 	struct virtio_media_queue_state *queue;
 	struct list_head *buffer_queue;
@@ -999,7 +1023,8 @@ static int virtio_media_g_input(struct file *file, void *fh, unsigned int *i)
 	u32 input;
 	int ret;
 
-	ret = virtio_media_send_wr_ioctl(fh, VIDIOC_G_INPUT, &input,
+	ret = virtio_media_send_wr_ioctl(file_to_v4l2_fh(file),
+					 VIDIOC_G_INPUT, &input,
 					 sizeof(input), sizeof(input));
 	if (ret)
 		return ret;
@@ -1013,7 +1038,8 @@ static int virtio_media_s_input(struct file *file, void *fh, unsigned int i)
 {
 	u32 input = i;
 
-	return virtio_media_send_wr_ioctl(fh, VIDIOC_S_INPUT, &input,
+	return virtio_media_send_wr_ioctl(file_to_v4l2_fh(file),
+					  VIDIOC_S_INPUT, &input,
 					  sizeof(input), sizeof(input));
 }
 
@@ -1022,7 +1048,8 @@ static int virtio_media_g_output(struct file *file, void *fh, unsigned int *o)
 	u32 output;
 	int ret;
 
-	ret = virtio_media_send_wr_ioctl(fh, VIDIOC_G_OUTPUT, &output,
+	ret = virtio_media_send_wr_ioctl(file_to_v4l2_fh(file),
+					 VIDIOC_G_OUTPUT, &output,
 					 sizeof(output), sizeof(output));
 	if (ret)
 		return ret;
@@ -1036,7 +1063,8 @@ static int virtio_media_s_output(struct file *file, void *fh, unsigned int o)
 {
 	u32 output = o;
 
-	return virtio_media_send_wr_ioctl(fh, VIDIOC_S_OUTPUT, &output,
+	return virtio_media_send_wr_ioctl(file_to_v4l2_fh(file),
+					  VIDIOC_S_OUTPUT, &output,
 					  sizeof(output), sizeof(output));
 }
 
@@ -1047,10 +1075,11 @@ static int virtio_media_s_output(struct file *file, void *fh, unsigned int o)
 static int virtio_media_decoder_cmd(struct file *file, void *fh,
 				    struct v4l2_decoder_cmd *cmd)
 {
-	struct virtio_media_session *session = fh_to_session(fh);
+	struct v4l2_fh *vfh = file_to_v4l2_fh(file);
+	struct virtio_media_session *session = fh_to_session(vfh);
 	int ret;
 
-	ret = virtio_media_send_wr_ioctl(fh, VIDIOC_DECODER_CMD, cmd,
+	ret = virtio_media_send_wr_ioctl(vfh, VIDIOC_DECODER_CMD, cmd,
 					 sizeof(*cmd), sizeof(*cmd));
 	if (ret)
 		return ret;
@@ -1074,7 +1103,8 @@ static int virtio_media_s_std(struct file *file, void *fh, v4l2_std_id s)
 {
 	int ret;
 
-	ret = virtio_media_send_w_ioctl(fh, VIDIOC_S_STD, &s, sizeof(s));
+	ret = virtio_media_send_w_ioctl(file_to_v4l2_fh(file), VIDIOC_S_STD,
+					&s, sizeof(s));
 	if (ret)
 		return ret;
 


### PR DESCRIPTION
These changes has been assembled with the intent submit a v4 of the patch set to upstream the virtio-media Linux kernel driver. These patches allow the code to be compiled and ran against new versions of the Linux kernel (it was tested again v7.1-rc1)